### PR TITLE
Fix recipe condition label for extra loadouts

### DIFF
--- a/Items/LoadoutVoodooDoll.cs
+++ b/Items/LoadoutVoodooDoll.cs
@@ -119,7 +119,7 @@ namespace ExtraLoadouts.Items {
                 .AddTile(TileID.DemonAltar);
 
             if (Extra) {
-                recipe.AddCondition(Language.GetText("Mods.ExtraLoadouts.RecipeConditions.ExtraLoadoutVoodooDoll" + Index),
+                recipe.AddCondition(Language.GetText("Mods.ExtraLoadouts.RecipeConditions.ExtraLoadoutVoodooDoll" + (Index + 1)),
                     () => Index < ModContent.GetInstance<LoadoutsConfig>().ExtraLoadouts);
             }
 


### PR DESCRIPTION
Fixed label that currently showing in recipe browser for first loadout: Mods.ExtraLoadouts.RecipeConditions.ExtraLoadoutVoodooDoll0

Also fixed for 2nd and 3rd showing label for 1st and 2nd